### PR TITLE
Support for Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ model Post {
 With `@nestjs/swagger`, you can generate an API specification from code.
 Routes, request bodies, query parameters, etc., are annotated with special decorators.
 Properties can be annotated with the `@ApiProperty()` decorator to add schema object information.
-They are partially added at runtime, which will then include `type`, `nullable`, etc.
+They are partially added at runtime, which will then include `type`, `nullable`, etc. 
 But additional information, such as description, need to be added manually.
 
 If using a generator like this, any custom `@ApiProperty()` annotation would be overridden when updating the DTOs.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ These classes can also be used with the built-in [ValidationPipe](https://docs.n
 
 This is a fork of [@vegardit/prisma-generator-nestjs-dto](https://github.com/vegardit/prisma-generator-nestjs-dto) and adds multiple features:
 
-- enhance fields with additional schema information, e.g., description, to generate a `@ApiProperty()` decorator (see [Schema Object annotations](#schema-object-annotations))
-- optionally add [validation decorators](#validation-decorators)
-- control output format with additional flags `flatResourceStructure`, `noDependencies`, and `outputType`
+* enhance fields with additional schema information, e.g., description, to generate a `@ApiProperty()` decorator (see [Schema Object annotations](#schema-object-annotations))
+* optionally add [validation decorators](#validation-decorators)
+* control output format with additional flags `flatResourceStructure`, `noDependencies`, and `outputType`
 
 ### ToDo
 
@@ -71,7 +71,7 @@ All parameters are optional.
 - [`classValidation`]: (default: `"false"`) - Add validation decorators from `class-validator`. Not compatible with `noDependencies = "true"` and `outputType = "interface"`.
 - [`noDependencies`]: (default: `"false"`) - Any imports and decorators that are specific to NestJS and Prisma are omitted, such that there are no references to external dependencies. This is useful if you want to generate appropriate DTOs for the frontend.
 - [`outputType`]: (default: `"class"`) - Output the DTOs as `class` or as `interface`. `interface` should only be used to generate DTOs for the frontend.
-- [`prettier`]: (default: `"false"`) - Should the output files should be stylized with Prettier?
+- [`prettier`]: (default: `"false"`) - Stylize output files with prettier.
 
 ## Annotations
 
@@ -110,24 +110,24 @@ To enhance a field with additional schema information, add the schema property p
 
 Currently, following schema properties are supported:
 
-- `description`
-- `minimum`
-- `maximum`
-- `exclusiveMinimum`
-- `exclusiveMaximum`
-- `minLength`
-- `maxLength`
-- `minItems`
-- `maxItems`
-- `example`
+* `description`
+* `minimum`
+* `maximum`
+* `exclusiveMinimum`
+* `exclusiveMaximum`
+* `minLength`
+* `maxLength`
+* `minItems`
+* `maxItems`
+* `example`
 
 Additionally, special data types are inferred and annotated as well:
 
-- `Int: { type: 'integer', format: 'int32' }`
-- `BigInt: { type: 'integer', format: 'int64' }`
-- `Float: { type: 'number', format: 'float' }`
-- `Decimal: { type: 'number', format: 'double' }`
-- `DateTime: { type: 'string', format: 'date-time' }`
+* `Int: { type: 'integer', format: 'int32' }`
+* `BigInt: { type: 'integer', format: 'int64' }`
+* `Float: { type: 'number', format: 'float' }`
+* `Decimal: { type: 'number', format: 'double' }`
+* `DateTime: { type: 'string', format: 'date-time' }`
 
 #### Example
 
@@ -152,7 +152,7 @@ reviewCount: number;
 ```
 
 Default values are added in `CreateDTO` and `UpdateDTO`.
-However, a field with a `@default()` attribute is hidden by default in `CreateDTO` and `UpdateDTO`,
+However, a field with a `@default()` attribute is hidden by default  in `CreateDTO` and `UpdateDTO`,
 hence requires `@DtoCreateOptional` and/or `@DtoUpdateOptional` to be present.
 
 ### Validation decorators
@@ -164,14 +164,14 @@ If the field is optional, it will add `@IsOptional()`, otherwise `@IsNotEmpty()`
 If the field is a list, it will add `@IsArray()`.
 Type validators are inferred from the field's type:
 
-- `String` &rarr; `@IsString()`
-- `Boolean` &rarr; `@IsBoolean()`
-- `Int` &rarr; `@IsInt()`
-- `BigInt` &rarr; `@IsInt()`
-- `Float:` &rarr; `@IsNumber()`
-- `Decimal:` &rarr; `@IsNumber()`
-- `DateTime` &rarr; `@IsRFC3339()`
-- `Json` &rarr; `@IsJSON()`
+* `String` &rarr; `@IsString()`
+* `Boolean` &rarr; `@IsBoolean()`
+* `Int` &rarr; `@IsInt()`
+* `BigInt` &rarr; `@IsInt()`
+* `Float:` &rarr; `@IsNumber()`
+* `Decimal:` &rarr; `@IsNumber()`
+* `DateTime` &rarr; `@IsRFC3339()`
+* `Json` &rarr; `@IsJSON()`
 
 All remaining [validation decorators](https://github.com/typestack/class-validator#validation-decorators) can be added in the comment/documentation section above the field.
 The parentheses can be omitted if not passing a value.
@@ -222,16 +222,16 @@ outputToNestJsResourceStructure = "true"
 }
 
 model Question {
-id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-/// @DtoReadOnly
-createdAt DateTime @default(now())
-/// @DtoRelationRequired
-createdBy User? @relation("CreatedQuestions", fields: [createdById], references: [id])
-createdById String? @db.Uuid
-updatedAt DateTime @updatedAt
-/// @DtoRelationRequired
-updatedBy User? @relation("UpdatedQuestions", fields: [updatedById], references: [id])
-updatedById String? @db.Uuid
+    id          String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+    /// @DtoReadOnly
+    createdAt   DateTime @default(now())
+    /// @DtoRelationRequired
+    createdBy   User? @relation("CreatedQuestions", fields: [createdById], references: [id])
+    createdById String? @db.Uuid
+    updatedAt   DateTime @updatedAt
+    /// @DtoRelationRequired
+    updatedBy   User? @relation("UpdatedQuestions", fields: [updatedById], references: [id])
+    updatedById String? @db.Uuid
 
     /// @DtoRelationRequired
     /// @DtoRelationCanConnectOnCreate

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ These classes can also be used with the built-in [ValidationPipe](https://docs.n
 
 This is a fork of [@vegardit/prisma-generator-nestjs-dto](https://github.com/vegardit/prisma-generator-nestjs-dto) and adds multiple features:
 
-* enhance fields with additional schema information, e.g., description, to generate a `@ApiProperty()` decorator (see [Schema Object annotations](#schema-object-annotations))
-* optionally add [validation decorators](#validation-decorators)
-* control output format with additional flags `flatResourceStructure`, `noDependencies`, and `outputType`
+- enhance fields with additional schema information, e.g., description, to generate a `@ApiProperty()` decorator (see [Schema Object annotations](#schema-object-annotations))
+- optionally add [validation decorators](#validation-decorators)
+- control output format with additional flags `flatResourceStructure`, `noDependencies`, and `outputType`
 
 ### ToDo
 
@@ -49,6 +49,7 @@ generator nestjsDto {
   fileNamingStyle                 = "camel"
   noDependencies                  = "false"
   outputType                      = "class"
+  prettier                        = "false"
 }
 ```
 
@@ -70,6 +71,7 @@ All parameters are optional.
 - [`classValidation`]: (default: `"false"`) - Add validation decorators from `class-validator`. Not compatible with `noDependencies = "true"` and `outputType = "interface"`.
 - [`noDependencies`]: (default: `"false"`) - Any imports and decorators that are specific to NestJS and Prisma are omitted, such that there are no references to external dependencies. This is useful if you want to generate appropriate DTOs for the frontend.
 - [`outputType`]: (default: `"class"`) - Output the DTOs as `class` or as `interface`. `interface` should only be used to generate DTOs for the frontend.
+- [`prettier`]: (default: `"false"`) - Should the output files should be stylized with Prettier?
 
 ## Annotations
 
@@ -100,7 +102,7 @@ model Post {
 With `@nestjs/swagger`, you can generate an API specification from code.
 Routes, request bodies, query parameters, etc., are annotated with special decorators.
 Properties can be annotated with the `@ApiProperty()` decorator to add schema object information.
-They are partially added at runtime, which will then include `type`, `nullable`, etc. 
+They are partially added at runtime, which will then include `type`, `nullable`, etc.
 But additional information, such as description, need to be added manually.
 
 If using a generator like this, any custom `@ApiProperty()` annotation would be overridden when updating the DTOs.
@@ -108,24 +110,24 @@ To enhance a field with additional schema information, add the schema property p
 
 Currently, following schema properties are supported:
 
-* `description`
-* `minimum`
-* `maximum`
-* `exclusiveMinimum`
-* `exclusiveMaximum`
-* `minLength`
-* `maxLength`
-* `minItems`
-* `maxItems`
-* `example`
+- `description`
+- `minimum`
+- `maximum`
+- `exclusiveMinimum`
+- `exclusiveMaximum`
+- `minLength`
+- `maxLength`
+- `minItems`
+- `maxItems`
+- `example`
 
 Additionally, special data types are inferred and annotated as well:
 
-* `Int: { type: 'integer', format: 'int32' }`
-* `BigInt: { type: 'integer', format: 'int64' }`
-* `Float: { type: 'number', format: 'float' }`
-* `Decimal: { type: 'number', format: 'double' }`
-* `DateTime: { type: 'string', format: 'date-time' }`
+- `Int: { type: 'integer', format: 'int32' }`
+- `BigInt: { type: 'integer', format: 'int64' }`
+- `Float: { type: 'number', format: 'float' }`
+- `Decimal: { type: 'number', format: 'double' }`
+- `DateTime: { type: 'string', format: 'date-time' }`
 
 #### Example
 
@@ -150,7 +152,7 @@ reviewCount: number;
 ```
 
 Default values are added in `CreateDTO` and `UpdateDTO`.
-However, a field with a `@default()` attribute is hidden by default  in `CreateDTO` and `UpdateDTO`,
+However, a field with a `@default()` attribute is hidden by default in `CreateDTO` and `UpdateDTO`,
 hence requires `@DtoCreateOptional` and/or `@DtoUpdateOptional` to be present.
 
 ### Validation decorators
@@ -162,14 +164,14 @@ If the field is optional, it will add `@IsOptional()`, otherwise `@IsNotEmpty()`
 If the field is a list, it will add `@IsArray()`.
 Type validators are inferred from the field's type:
 
-* `String` &rarr; `@IsString()`
-* `Boolean` &rarr; `@IsBoolean()`
-* `Int` &rarr; `@IsInt()`
-* `BigInt` &rarr; `@IsInt()`
-* `Float:` &rarr; `@IsNumber()`
-* `Decimal:` &rarr; `@IsNumber()`
-* `DateTime` &rarr; `@IsRFC3339()`
-* `Json` &rarr; `@IsJSON()`
+- `String` &rarr; `@IsString()`
+- `Boolean` &rarr; `@IsBoolean()`
+- `Int` &rarr; `@IsInt()`
+- `BigInt` &rarr; `@IsInt()`
+- `Float:` &rarr; `@IsNumber()`
+- `Decimal:` &rarr; `@IsNumber()`
+- `DateTime` &rarr; `@IsRFC3339()`
+- `Json` &rarr; `@IsJSON()`
 
 All remaining [validation decorators](https://github.com/typestack/class-validator#validation-decorators) can be added in the comment/documentation section above the field.
 The parentheses can be omitted if not passing a value.
@@ -220,16 +222,16 @@ outputToNestJsResourceStructure = "true"
 }
 
 model Question {
-    id          String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-    /// @DtoReadOnly
-    createdAt   DateTime @default(now())
-    /// @DtoRelationRequired
-    createdBy   User? @relation("CreatedQuestions", fields: [createdById], references: [id])
-    createdById String? @db.Uuid
-    updatedAt   DateTime @updatedAt
-    /// @DtoRelationRequired
-    updatedBy   User? @relation("UpdatedQuestions", fields: [updatedById], references: [id])
-    updatedById String? @db.Uuid
+id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+/// @DtoReadOnly
+createdAt DateTime @default(now())
+/// @DtoRelationRequired
+createdBy User? @relation("CreatedQuestions", fields: [createdById], references: [id])
+createdById String? @db.Uuid
+updatedAt DateTime @updatedAt
+/// @DtoRelationRequired
+updatedBy User? @relation("UpdatedQuestions", fields: [updatedById], references: [id])
+updatedById String? @db.Uuid
 
     /// @DtoRelationRequired
     /// @DtoRelationCanConnectOnCreate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@brakebein/prisma-generator-nestjs-dto",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brakebein/prisma-generator-nestjs-dto",
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/generator-helper": "^3.2.1",
         "@prisma/sdk": "^3.2.1",
         "case": "^1.6.3",
         "make-dir": "^3.1.0",
+        "prettier": "^2.7.1",
         "slash": "^3.0.0",
         "tar": "^6.1.11"
       },
@@ -28,7 +29,6 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.2.4",
-        "prettier": "^2.4.1",
         "prisma": "^3.2.1",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
@@ -6981,15 +6981,17 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true,
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -13897,10 +13899,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "email": "bk@vegardit.com",
     "url": "https://vegardit.com/"
   },
-  "contributors": [{
-    "name": "Brakebein",
-    "url": "https://github.com/Brakebein"
-  }],
+  "contributors": [
+    {
+      "name": "Brakebein",
+      "url": "https://github.com/Brakebein"
+    }
+  ],
   "main": "dist/index.js",
   "keywords": [
     "prisma",
@@ -56,6 +58,7 @@
     "@prisma/sdk": "^3.2.1",
     "case": "^1.6.3",
     "make-dir": "^3.1.0",
+    "prettier": "^2.7.1",
     "slash": "^3.0.0",
     "tar": "^6.1.11"
   },
@@ -68,7 +71,6 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.2.4",
-    "prettier": "^2.4.1",
     "prisma": "^3.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.5",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,10 @@
     "email": "bk@vegardit.com",
     "url": "https://vegardit.com/"
   },
-  "contributors": [
-    {
+  "contributors": [{
       "name": "Brakebein",
       "url": "https://github.com/Brakebein"
-    }
-  ],
+    }],
   "main": "dist/index.js",
   "keywords": [
     "prisma",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "url": "https://vegardit.com/"
   },
   "contributors": [{
-      "name": "Brakebein",
-      "url": "https://github.com/Brakebein"
-    }],
+    "name": "Brakebein",
+    "url": "https://github.com/Brakebein"
+  }],
   "main": "dist/index.js",
   "keywords": [
     "prisma",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ generator nestjsDto {
   classValidation                 = "true"
   noDependencies                  = "false"
   outputType                      = "class"
+  prettier                        = "true"
 }
 
 model Product {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import makeDir from 'make-dir';
 import { generatorHandler } from '@prisma/generator-helper';
 import { parseEnvValue } from '@prisma/sdk';
+import prettier from 'prettier';
 
 import { run } from './generator';
 
@@ -20,7 +21,7 @@ export const stringToBoolean = (input: string, defaultValue = false) => {
   return defaultValue;
 };
 
-export const generate = (options: GeneratorOptions) => {
+export const generate = async (options: GeneratorOptions) => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const output = parseEnvValue(options.generator.output!);
 
@@ -121,6 +122,35 @@ export const generate = (options: GeneratorOptions) => {
 
   const indexCollections: Record<string, WriteableFileSpecs> = {};
 
+  const applyPrettier = stringToBoolean(
+    options.generator.config.prettier,
+    false,
+  );
+
+  let prettierConfig: prettier.Options = {};
+  if (applyPrettier) {
+    const prettierConfigFile = await prettier.resolveConfigFile(process.cwd());
+    if (!prettierConfigFile) {
+      console.log('Stylizing output DTOs with the default Prettier config.');
+    } else {
+      console.log(
+        `Stylizing output DTOs with found Prettier config. (${prettierConfigFile})`,
+      );
+    }
+
+    if (prettierConfigFile) {
+      const resolvedConfig = await prettier.resolveConfig(prettierConfigFile, {
+        config: prettierConfigFile,
+      });
+
+      if (resolvedConfig) prettierConfig = resolvedConfig;
+    }
+
+    // Ensures that there are no parsing issues
+    // We know that the output files are always Typescript
+    prettierConfig.parser = 'typescript';
+  }
+
   if (reExport) {
     results.forEach(({ fileName }) => {
       const dirName = path.dirname(fileName);
@@ -141,6 +171,9 @@ export const generate = (options: GeneratorOptions) => {
       .concat(Object.values(indexCollections))
       .map(async ({ fileName, content }) => {
         await makeDir(path.dirname(fileName));
+
+        if (applyPrettier) content = prettier.format(content, prettierConfig);
+
         return fs.writeFile(fileName, content);
       }),
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import makeDir from 'make-dir';
 import { generatorHandler } from '@prisma/generator-helper';
-import { parseEnvValue } from '@prisma/sdk';
+import { parseEnvValue, logger } from '@prisma/sdk';
 import prettier from 'prettier';
 
 import { run } from './generator';
@@ -131,9 +131,9 @@ export const generate = async (options: GeneratorOptions) => {
   if (applyPrettier) {
     const prettierConfigFile = await prettier.resolveConfigFile(process.cwd());
     if (!prettierConfigFile) {
-      console.log('Stylizing output DTOs with the default Prettier config.');
+      logger.info('Stylizing output DTOs with the default Prettier config.');
     } else {
-      console.log(
+      logger.info(
         `Stylizing output DTOs with found Prettier config. (${prettierConfigFile})`,
       );
     }


### PR DESCRIPTION
This PR adds support for stylization of the output files, utilizing the Prettier API.

I made it default `false` since most people do not care about the stylization of any auto-generated code, but I personally enjoy cleaner output when debugging or checking the DTO for a quick reference.