### PR TITLE
feat: support custom prisma-client import path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brakebein/prisma-generator-nestjs-dto",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brakebein/prisma-generator-nestjs-dto",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/generator-helper": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "cleanup:generated": "rimraf src/@generated",
     "pregenerate": "npm run cleanup:generated",
     "generate": "npx prisma generate && npm run format -- --loglevel error",
-    "generate:mongo": "npx prisma generate --schema ./prisma/mongodb.prisma && npm run format -- --loglevel error"
+    "generate:mongo": "npx prisma generate --schema ./prisma/mongodb.prisma && npm run format -- --loglevel error",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/generator/compute-model-params/compute-create-dto-params.ts
+++ b/src/generator/compute-model-params/compute-create-dto-params.ts
@@ -232,7 +232,10 @@ export const computeCreateDtoParams = ({
     });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers.config.prismaClientImportPath,
+  );
 
   return {
     model,

--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -180,7 +180,10 @@ export const computeEntityParams = ({
     imports.unshift({ from: '@nestjs/swagger', destruct });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers.config.prismaClientImportPath,
+  );
 
   return {
     model,

--- a/src/generator/compute-model-params/compute-plain-dto-params.ts
+++ b/src/generator/compute-model-params/compute-plain-dto-params.ts
@@ -115,7 +115,10 @@ export const computePlainDtoParams = ({
     imports.unshift({ from: '@nestjs/swagger', destruct });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers.config.prismaClientImportPath,
+  );
 
   return {
     model,

--- a/src/generator/compute-model-params/compute-update-dto-params.ts
+++ b/src/generator/compute-model-params/compute-update-dto-params.ts
@@ -238,7 +238,10 @@ export const computeUpdateDtoParams = ({
     });
   }
 
-  const importPrismaClient = makeImportsFromPrismaClient(fields);
+  const importPrismaClient = makeImportsFromPrismaClient(
+    fields,
+    templateHelpers.config.prismaClientImportPath,
+  );
 
   return {
     model,

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -44,6 +44,7 @@ export function concatUniqueIntoArray<T = any>(
 
 export const makeImportsFromPrismaClient = (
   fields: ParsedField[],
+  prismaClientImportPath: string,
 ): ImportStatementParams[] => {
   const enumsToImport = uniq(
     fields.filter(({ kind }) => kind === 'enum').map(({ type }) => type),
@@ -60,7 +61,7 @@ export const makeImportsFromPrismaClient = (
     enumsToImport.length || importPrisma
       ? [
           {
-            from: '@prisma/client',
+            from: prismaClientImportPath,
             destruct: importPrisma
               ? ['Prisma', ...enumsToImport]
               : enumsToImport,

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -30,6 +30,7 @@ interface RunParam {
   classValidation: boolean;
   outputType: string;
   noDependencies: boolean;
+  prismaClientImportPath: string;
 }
 
 export const run = ({
@@ -45,6 +46,7 @@ export const run = ({
     classValidation,
     outputType,
     noDependencies,
+    prismaClientImportPath,
     ...preAndSuffixes
   } = options;
 
@@ -63,6 +65,7 @@ export const run = ({
     classValidation,
     outputType,
     noDependencies,
+    prismaClientImportPath,
     ...preAndSuffixes,
   });
   const allModels = dmmf.datamodel.models;

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -97,6 +97,7 @@ interface MakeHelpersParam {
   classValidation: boolean;
   outputType: string;
   noDependencies: boolean;
+  prismaClientImportPath: string;
 }
 export const makeHelpers = ({
   connectDtoPrefix,
@@ -110,6 +111,7 @@ export const makeHelpers = ({
   classValidation,
   outputType,
   noDependencies,
+  prismaClientImportPath,
 }: MakeHelpersParam) => {
   const className = (name: string, prefix = '', suffix = '') =>
     `${prefix}${transformClassNameCase(name)}${suffix}`;
@@ -240,6 +242,7 @@ export const makeHelpers = ({
       classValidation,
       outputType,
       noDependencies,
+      prismaClientImportPath,
     },
     apiExtraModels,
     entityName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,28 @@ export const generate = async (options: GeneratorOptions) => {
     false,
   );
 
+  const prismaClientGenerator = options.otherGenerators.find(
+    (config) => config.name === 'client',
+  );
+  const prismaClientOutputPath = prismaClientGenerator?.output?.value;
+  let prismaClientImportPath = '@prisma/client';
+  if (
+    prismaClientOutputPath &&
+    !prismaClientOutputPath.endsWith(
+      ['node_modules', '@prisma', 'client'].join(path.sep),
+    )
+  ) {
+    const withStructure = outputToNestJsResourceStructure
+      ? flatResourceStructure
+        ? '../'
+        : '../../'
+      : '';
+    prismaClientImportPath =
+      './' +
+      withStructure +
+      path.relative(output, prismaClientOutputPath).replace('\\', '/');
+  }
+
   if (classValidation && outputType !== 'class') {
     throw new Error(
       `To use 'validation' validation decorators, 'outputType' must be 'class'.`,
@@ -117,6 +139,7 @@ export const generate = async (options: GeneratorOptions) => {
     classValidation,
     outputType,
     noDependencies,
+    prismaClientImportPath,
   });
 
   const indexCollections: Record<string, WriteableFileSpecs> = {};


### PR DESCRIPTION
First, thanks a lot for your awesome work on this generator! It is super helpful that you move the project forward.

Our Prisma Client is generated into a custom output folder, which does not work with your version, as your default import of the `@prisma/client` for enums is hard-coded.

This PR reads the output path of the Prisma Client Generator and uses it to import the client correctly.

Let me know if this helps or if you need something else to merge it.