### PR TITLE
Allow create DTO fields to be nullable

### DIFF
--- a/src/generator/compute-model-params/compute-create-dto-params.ts
+++ b/src/generator/compute-model-params/compute-create-dto-params.ts
@@ -138,6 +138,9 @@ export const computeCreateDtoParams = ({
     if (isDtoOptional) {
       overrides.isRequired = false;
     }
+    if (!field.isRequired) {
+      overrides.isNullable = true;
+    }
 
     if (isType(field)) {
       // don't try to import the class we're preparing params for


### PR DESCRIPTION
If a field is not marked as required, mark it as nullable in the create DTO