### PR TITLE
feature: add @DtoUpdateRequired

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brakebein/prisma-generator-nestjs-dto",
-  "version": "1.19.3",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brakebein/prisma-generator-nestjs-dto",
-      "version": "1.19.3",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/client": "^4.16.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brakebein/prisma-generator-nestjs-dto",
   "description": "Generates DTO and Entity classes from Prisma Schema for NestJS",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Benjamin Kroeger",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Product {
   /// @Contains('Product')
   /// @description Project's name
   /// @example My first product
+  /// @DtoUpdateRequired
   name            String        @db.VarChar(255)
   description     String        @db.VarChar(1024)
   /// @maxItems 5

--- a/src/generator/annotations.ts
+++ b/src/generator/annotations.ts
@@ -7,6 +7,7 @@ export const DTO_CONNECT_HIDDEN = /@DtoConnectHidden/;
 export const DTO_API_HIDDEN = /@DtoApiHidden/;
 export const DTO_CREATE_OPTIONAL = /@DtoCreateOptional/;
 export const DTO_UPDATE_OPTIONAL = /@DtoUpdateOptional/;
+export const DTO_UPDATE_REQUIRED = /@DtoUpdateRequired/;
 export const DTO_RELATION_REQUIRED = /@DtoRelationRequired/;
 export const DTO_RELATION_INCLUDE_ID = /@DtoRelationIncludeId/;
 export const DTO_RELATION_CAN_CREATE_ON_CREATE =

--- a/src/generator/compute-model-params/compute-update-dto-params.ts
+++ b/src/generator/compute-model-params/compute-update-dto-params.ts
@@ -1,5 +1,5 @@
-import slash from 'slash';
 import path from 'node:path';
+import slash from 'slash';
 import {
   DTO_API_HIDDEN,
   DTO_RELATION_CAN_CONNECT_ON_UPDATE,
@@ -10,6 +10,7 @@ import {
   DTO_TYPE_FULL_UPDATE,
   DTO_UPDATE_HIDDEN,
   DTO_UPDATE_OPTIONAL,
+  DTO_UPDATE_REQUIRED,
   DTO_UPDATE_VALIDATE_IF,
 } from '../annotations';
 import {
@@ -34,20 +35,20 @@ import {
 } from '../helpers';
 
 import type { DMMF } from '@prisma/generator-helper';
-import type { TemplateHelpers } from '../template-helpers';
-import type {
-  Model,
-  UpdateDtoParams,
-  ImportStatementParams,
-  ParsedField,
-  IDecorators,
-  IClassValidator,
-} from '../types';
 import {
   makeImportsFromNestjsSwagger,
   parseApiProperty,
 } from '../api-decorator';
 import { parseClassValidators } from '../class-validator';
+import type { TemplateHelpers } from '../template-helpers';
+import type {
+  IClassValidator,
+  IDecorators,
+  ImportStatementParams,
+  Model,
+  ParsedField,
+  UpdateDtoParams,
+} from '../types';
 
 interface ComputeUpdateDtoParamsParam {
   model: Model;
@@ -129,6 +130,10 @@ export const computeUpdateDtoParams = ({
       if (isId(field)) return result;
       if (isUpdatedAt(field)) return result;
       if (isRequiredWithDefaultValue(field)) return result;
+    }
+
+    if (isAnnotatedWith(field, DTO_UPDATE_REQUIRED)) {
+      overrides.isRequired = true;
     }
 
     if (isType(field)) {


### PR DESCRIPTION
Related issue: https://github.com/Brakebein/prisma-generator-nestjs-dto/issues/40

This PR adds the following annotation: @DtoUpdateRequired
Adding this allows users to set a property of an update DTO to required:
- No @IsOptional()
- No required: true in @ApiProperty
This helps users (like me) who use strict type checking by removing the possibility for the property being undefined.

Minor changes, all tests run successful, `npm run generate` results in correct generation.