### PR TITLE
feature: Add outputApiPropertyType setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ generator nestjsDto {
   definiteAssignmentAssertion     = "false"
   requiredResponseApiProperty     = "true"
   prettier                        = "false"
+  outputApiPropertyType           = "true"
 }
 ```
 
@@ -82,6 +83,7 @@ All parameters are optional.
 | `definiteAssignmentAssertion = "false"`                          | Add a definite assignment assertion operator `!` to required fields, which is required if `strict` and/or `strictPropertyInitialization` is set `true` in your tsconfig.json's `compilerOptions`.                    |
 | `requiredResponseApiProperty = "true"`                           | If `false`, add `@ApiRequired({ required: false })` to response DTO properties. Otherwise, use `required` defaults always to `true` unless field is optional.                                                        |
 | `prettier = "false"`                                             | Stylize output files with prettier.                                                                                                                                                                                  |
+| `outputApiPropertyType = "true"`                                 | Disable the type property inside @ApiProperty() |
 
 ## Annotations
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brakebein/prisma-generator-nestjs-dto",
   "description": "Generates DTO and Entity classes from Prisma Schema for NestJS",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Benjamin Kroeger",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ generator nestjsDto {
   outputType                      = "class"
   definiteAssignmentAssertion     = "true"
   prettier                        = "true"
+  outputApiPropertyType           = "true"
 }
 
 model Product {

--- a/src/generator/compute-model-params/compute-connect-dto-params.ts
+++ b/src/generator/compute-model-params/compute-connect-dto-params.ts
@@ -131,7 +131,10 @@ export const computeConnectDtoParams = ({
           ...field,
           ...overrides,
         },
-        { default: false },
+        {
+          default: false,
+          type: templateHelpers.config.outputApiPropertyType,
+        },
       );
       const typeProperty = decorators.apiProperties.find(
         (p) => p.name === 'type',

--- a/src/generator/compute-model-params/compute-create-dto-params.ts
+++ b/src/generator/compute-model-params/compute-create-dto-params.ts
@@ -203,10 +203,14 @@ export const computeCreateDtoParams = ({
       if (isAnnotatedWith(field, DTO_API_HIDDEN)) {
         decorators.apiHideProperty = true;
       } else {
+        // If outputApiPropertyType is false, make sure to set includeType false, otherwise use negated overrides.type
+        const includeType = templateHelpers.config.outputApiPropertyType
+          ? !overrides.type
+          : false;
         decorators.apiProperties = parseApiProperty(field, {
-          type: !overrides.type,
+          type: includeType,
         });
-        if (overrides.type)
+        if (overrides.type && templateHelpers.config.outputApiPropertyType)
           decorators.apiProperties.push({
             name: 'type',
             value: overrides.type,

--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -175,7 +175,10 @@ export const computeEntityParams = ({
               : false,
             isNullable: !field.isRequired,
           },
-          { default: false },
+          {
+            default: false,
+            type: templateHelpers.config.outputApiPropertyType,
+          },
         );
         const typeProperty = decorators.apiProperties.find(
           (p) => p.name === 'type',

--- a/src/generator/compute-model-params/compute-plain-dto-params.ts
+++ b/src/generator/compute-model-params/compute-plain-dto-params.ts
@@ -110,7 +110,10 @@ export const computePlainDtoParams = ({
               : false,
             isNullable: !field.isRequired,
           },
-          { default: false },
+          {
+            default: false,
+            type: templateHelpers.config.outputApiPropertyType,
+          },
         );
         const typeProperty = decorators.apiProperties.find(
           (p) => p.name === 'type',

--- a/src/generator/compute-model-params/compute-update-dto-params.ts
+++ b/src/generator/compute-model-params/compute-update-dto-params.ts
@@ -206,6 +206,10 @@ export const computeUpdateDtoParams = ({
       if (isAnnotatedWith(field, DTO_API_HIDDEN)) {
         decorators.apiHideProperty = true;
       } else {
+        // If outputApiPropertyType is false, make sure to set includeType false, otherwise use negated overrides.type
+        const includeType = templateHelpers.config.outputApiPropertyType
+          ? !overrides.type
+          : false;
         decorators.apiProperties = parseApiProperty(
           {
             ...field,
@@ -213,10 +217,10 @@ export const computeUpdateDtoParams = ({
             isNullable: !field.isRequired,
           },
           {
-            type: !overrides.type,
+            type: includeType,
           },
         );
-        if (overrides.type)
+        if (overrides.type && templateHelpers.config.outputApiPropertyType)
           decorators.apiProperties.push({
             name: 'type',
             value: overrides.type,

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -551,7 +551,15 @@ export const generateUniqueInput = ({
     }
 
     if (!t.config.noDependencies) {
-      decorators.apiProperties = parseApiProperty({ ...field, ...overrides });
+      decorators.apiProperties = parseApiProperty(
+        {
+          ...field,
+          ...overrides,
+        },
+        {
+          type: t.config.outputApiPropertyType,
+        },
+      );
       const typeProperty = decorators.apiProperties.find(
         (p) => p.name === 'type',
       );

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -33,6 +33,7 @@ interface RunParam {
   definiteAssignmentAssertion: boolean;
   requiredResponseApiProperty: boolean;
   prismaClientImportPath: string;
+  outputApiPropertyType: boolean;
 }
 
 export const run = ({
@@ -51,6 +52,7 @@ export const run = ({
     definiteAssignmentAssertion,
     requiredResponseApiProperty,
     prismaClientImportPath,
+    outputApiPropertyType,
     ...preAndSuffixes
   } = options;
 
@@ -72,6 +74,7 @@ export const run = ({
     definiteAssignmentAssertion,
     prismaClientImportPath,
     requiredResponseApiProperty,
+    outputApiPropertyType,
     ...preAndSuffixes,
   });
   const allModels = dmmf.datamodel.models;

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -103,6 +103,7 @@ interface MakeHelpersParam {
   definiteAssignmentAssertion: boolean;
   requiredResponseApiProperty: boolean;
   prismaClientImportPath: string;
+  outputApiPropertyType: boolean;
 }
 export const makeHelpers = ({
   connectDtoPrefix,
@@ -119,6 +120,7 @@ export const makeHelpers = ({
   definiteAssignmentAssertion,
   requiredResponseApiProperty,
   prismaClientImportPath,
+  outputApiPropertyType,
 }: MakeHelpersParam) => {
   const className = (name: string, prefix = '', suffix = '') =>
     `${prefix}${transformClassNameCase(name)}${suffix}`;
@@ -263,6 +265,7 @@ export const makeHelpers = ({
       definiteAssignmentAssertion,
       requiredResponseApiProperty,
       prismaClientImportPath,
+      outputApiPropertyType,
     },
     apiExtraModels,
     entityName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,11 @@ export const generate = async (options: GeneratorOptions) => {
     }
   }
 
+  const outputApiPropertyType = stringToBoolean(
+    options.generator.config.outputApiPropertyType,
+    true,
+  );
+
   const results = run({
     output,
     dmmf: options.dmmf,
@@ -163,6 +168,7 @@ export const generate = async (options: GeneratorOptions) => {
     definiteAssignmentAssertion,
     requiredResponseApiProperty,
     prismaClientImportPath,
+    outputApiPropertyType,
   });
 
   const indexCollections: Record<string, WriteableFileSpecs> = {};


### PR DESCRIPTION
As discussed in https://github.com/Brakebein/prisma-generator-nestjs-dto/issues/39

This PR adds the following setting: outputApiPropertyType
It defaults to true which is the current default behavior. 
Setting it to false keeps @ApiProperty() it removes the type property.

All tests run succesfull, npm run generate results in correct generation.