### PR TITLE
fix `IsAlphanumeric` class-validator

### DIFF
--- a/src/generator/class-validator.ts
+++ b/src/generator/class-validator.ts
@@ -13,7 +13,7 @@ const validatorsWithoutParams = [
   'IsBooleanString',
   'IsDateString',
   'IsAlpha',
-  'IsAlphaNumeric',
+  'IsAlphanumeric',
   'IsAscii',
   'IsBase32',
   'IsBase58',


### PR DESCRIPTION
the decorator uses a lowercase `n` in `IsAlphanumeric`