### PR TITLE
fix: correct reference to self in case of self relation with wrapRelationsAsType

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ generator nestjsDto {
   definiteAssignmentAssertion     = "true"
   prettier                        = "true"
   outputApiPropertyType           = "true"
-  wrapRelationsAsType             = "false"
+  wrapRelationsAsType             = "true"
 }
 
 model Product {
@@ -118,6 +118,10 @@ model Category {
   /// @DtoOverrideType(ProductFoo2, ./product.foo2)
   /// @DtoOverrideApiPropertyType(ProductFoo3, ./product.foo3)
   product   Product[]
+
+  parentCategoryId String?
+  parentCategory   Category?  @relation(name: "ParentCategory", fields: [parentCategoryId], references: [id])
+  childCategories  Category[] @relation("ParentCategory")
 }
 
 model Company {

--- a/src/generator/compute-model-params/compute-connect-dto-params.ts
+++ b/src/generator/compute-model-params/compute-connect-dto-params.ts
@@ -172,7 +172,11 @@ export const computeConnectDtoParams = ({
       }
     }
 
-    return mapDMMFToParsedField(field, overrides, decorators);
+    return mapDMMFToParsedField(
+      field,
+      { ...overrides, modelName: model.name },
+      decorators,
+    );
   });
 
   const importPrismaClient = makeImportsFromPrismaClient(

--- a/src/generator/compute-model-params/compute-create-dto-params.ts
+++ b/src/generator/compute-model-params/compute-create-dto-params.ts
@@ -271,7 +271,14 @@ export const computeCreateDtoParams = ({
       }
     }
 
-    return [...result, mapDMMFToParsedField(field, overrides, decorators)];
+    return [
+      ...result,
+      mapDMMFToParsedField(
+        field,
+        { ...overrides, modelName: model.name },
+        decorators,
+      ),
+    ];
   }, [] as ParsedField[]);
 
   const importPrismaClient = makeImportsFromPrismaClient(

--- a/src/generator/compute-model-params/compute-entity-params.ts
+++ b/src/generator/compute-model-params/compute-entity-params.ts
@@ -141,7 +141,8 @@ export const computeEntityParams = ({
         imports.push({
           destruct: [
             importName,
-            ...(templateHelpers.config.wrapRelationsAsType
+            ...(templateHelpers.config.wrapRelationsAsType &&
+            field.type !== model.name
               ? [`type ${importName} as ${importName}AsType`]
               : []),
           ],
@@ -216,7 +217,14 @@ export const computeEntityParams = ({
       }
     }
 
-    return [...result, mapDMMFToParsedField(field, overrides, decorators)];
+    return [
+      ...result,
+      mapDMMFToParsedField(
+        field,
+        { ...overrides, modelName: model.name },
+        decorators,
+      ),
+    ];
   }, [] as ParsedField[]);
 
   const importPrismaClient = makeImportsFromPrismaClient(

--- a/src/generator/compute-model-params/compute-plain-dto-params.ts
+++ b/src/generator/compute-model-params/compute-plain-dto-params.ts
@@ -147,7 +147,14 @@ export const computePlainDtoParams = ({
       }
     }
 
-    return [...result, mapDMMFToParsedField(field, overrides, decorators)];
+    return [
+      ...result,
+      mapDMMFToParsedField(
+        field,
+        { ...overrides, modelName: model.name },
+        decorators,
+      ),
+    ];
   }, [] as ParsedField[]);
 
   const importPrismaClient = makeImportsFromPrismaClient(

--- a/src/generator/compute-model-params/compute-update-dto-params.ts
+++ b/src/generator/compute-model-params/compute-update-dto-params.ts
@@ -273,7 +273,14 @@ export const computeUpdateDtoParams = ({
       }
     }
 
-    return [...result, mapDMMFToParsedField(field, overrides, decorators)];
+    return [
+      ...result,
+      mapDMMFToParsedField(
+        field,
+        { ...overrides, modelName: model.name },
+        decorators,
+      ),
+    ];
   }, [] as ParsedField[]);
 
   const importPrismaClient = makeImportsFromPrismaClient(

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -214,7 +214,10 @@ export const makeHelpers = ({
           : (field.relationName
               ? entityName(field.type)
               : dtoName(field.type, doFullUpdate ? 'create' : dtoType)) +
-            when(wrapRelationsAsType, 'AsType'))
+            when(
+              wrapRelationsAsType && field.type !== field.modelName,
+              'AsType',
+            ))
     }${when(field.isList, '[]')}`;
   };
 

--- a/src/generator/types.ts
+++ b/src/generator/types.ts
@@ -12,6 +12,7 @@ export interface ParsedField {
   kind: DMMF.FieldKind | 'relation-input';
   name: string;
   type: string;
+  modelName?: string;
   documentation?: string;
   isRequired: boolean;
   isList: boolean;


### PR DESCRIPTION
When using `wrapRelationsAsType`, models that reference themselves would also gain the `AsType` suffix, which breaks the Entity DTO.

For example:

```
model Category {
  ...
  parentCategoryId String?
  parentCategory   Category?  @relation(name: "ParentCategory", fields: [parentCategoryId], references: [id])
  childCategories  Category[] @relation("ParentCategory")
}
```

would result in a CategoryEntity with the following field:

```
export class CategoryEntity {
  ...
  @ApiProperty({
      type: () => CategoryEntityAsType,
      isArray: true,
      required: false,
    })
    childCategories?: CategoryEntityAsType[];
  }
```

This fix corrects that, so that references to self are not affected.